### PR TITLE
Refactor tab sorting to single handler

### DIFF
--- a/characters.html
+++ b/characters.html
@@ -5,9 +5,9 @@ title: "Character Wiki"
 
 <!-- Sorting Tabs -->
 <div class="character-sort-tabs">
-  <button id="popularity-tab" class="sort-tab active">Popularity</button>
-  <button id="alphabetical-tab" class="sort-tab">Alphabetical</button>
-  <button id="sorted-tab" class="sort-tab">Sorted</button>
+  <button id="popularity-tab" class="sort-tab active" data-target="popularity-container">Popularity</button>
+  <button id="alphabetical-tab" class="sort-tab" data-target="alphabetical-container">Alphabetical</button>
+  <button id="sorted-tab" class="sort-tab" data-target="sorted-container">Sorted</button>
 </div>
 
 <!-- Popularity View (Default) -->
@@ -85,67 +85,4 @@ title: "Character Wiki"
   {% endfor %}
 </div>
 
-<script>
-document.addEventListener('DOMContentLoaded', function(){
-  var popularityTab = document.getElementById('popularity-tab');
-  var alphabeticalTab = document.getElementById('alphabetical-tab');
-  var sortedTab = document.getElementById('sorted-tab');
 
-  var popularityContainer = document.getElementById('popularity-container');
-  var alphabeticalContainer = document.getElementById('alphabetical-container');
-  var sortedContainer = document.getElementById('sorted-container');
-
-  function clearActive() {
-    var tabs = document.querySelectorAll('.sort-tab');
-    tabs.forEach(function(tab){
-      tab.classList.remove('active');
-    });
-  }
-
-  if (popularityTab) {
-    popularityTab.addEventListener('click', function(){
-      clearActive();
-      popularityTab.classList.add('active');
-      popularityContainer.style.display = 'grid';
-      alphabeticalContainer.style.display = 'none';
-      sortedContainer.style.display = 'none';
-    });
-  }
-
-  if (alphabeticalTab) {
-    alphabeticalTab.addEventListener('click', function(){
-      clearActive();
-      alphabeticalTab.classList.add('active');
-      popularityContainer.style.display = 'none';
-      alphabeticalContainer.style.display = 'grid';
-      sortedContainer.style.display = 'none';
-    });
-  }
-
-  if (sortedTab) {
-    sortedTab.addEventListener('click', function(){
-      clearActive();
-      sortedTab.classList.add('active');
-      popularityContainer.style.display = 'none';
-      alphabeticalContainer.style.display = 'none';
-      sortedContainer.style.display = 'block';
-      // Reset: show the category list and hide all category detail containers.
-      document.getElementById('sorted-category-list').style.display = 'grid';
-      var detailContainers = document.querySelectorAll('#sorted-container > .character-view-container[id^="category-"]');
-      detailContainers.forEach(function(container){
-        container.style.display = 'none';
-      });
-    });
-  }
-});
-
-function loadCategory(slug) {
-  // Hide the category list.
-  document.getElementById('sorted-category-list').style.display = 'none';
-  // Show the container for the chosen category.
-  var container = document.getElementById('category-' + slug + '-container');
-  if (container) {
-    container.style.display = 'grid';
-  }
-}
-</script>

--- a/js/main.js
+++ b/js/main.js
@@ -1,59 +1,40 @@
 // main.js  — COTD uses SHA-256 + rejection sampling (date-seeded, deterministic, natural-looking)
 
 /* ----------------- Tabs: Popularity / Alphabetical / Sorted ----------------- */
-document.addEventListener('DOMContentLoaded', function(){
-  var popularityTab = document.getElementById('popularity-tab');
-  var alphabeticalTab = document.getElementById('alphabetical-tab');
-  var sortedTab = document.getElementById('sorted-tab');
+document.addEventListener('DOMContentLoaded', function() {
+  var tabs = document.querySelectorAll('.sort-tab[data-target]');
+  var containers = {};
 
-  var popularityContainer = document.getElementById('popularity-container');
-  var alphabeticalContainer = document.getElementById('alphabetical-container');
-  var sortedContainer = document.getElementById('sorted-container');
+  tabs.forEach(function(tab) {
+    var targetId = tab.getAttribute('data-target');
+    containers[targetId] = document.getElementById(targetId);
 
-  function clearActive() {
-    var tabs = document.querySelectorAll('.sort-tab');
-    tabs.forEach(function(tab){
-      tab.classList.remove('active');
-    });
-  }
+    tab.addEventListener('click', function() {
+      tabs.forEach(function(t) {
+        t.classList.remove('active');
+      });
+      this.classList.add('active');
 
-  if(popularityTab) {
-    popularityTab.addEventListener('click', function(){
-      clearActive();
-      popularityTab.classList.add('active');
-      if(popularityContainer) popularityContainer.style.display = 'grid';
-      if(alphabeticalContainer) alphabeticalContainer.style.display = 'none';
-      if(sortedContainer) alphabeticalContainer.style.display = 'none';
-    });
-  }
+      Object.values(containers).forEach(function(container) {
+        if (container) container.style.display = 'none';
+      });
 
-  if(alphabeticalTab) {
-    alphabeticalTab.addEventListener('click', function(){
-      clearActive();
-      alphabeticalTab.classList.add('active');
-      if(popularityContainer) popularityContainer.style.display = 'none';
-      if(alphabeticalContainer) alphabeticalContainer.style.display = 'grid';
-      if(sortedContainer) alphabeticalContainer.style.display = 'none';
-    });
-  }
-
-  if(sortedTab) {
-    sortedTab.addEventListener('click', function(){
-      clearActive();
-      sortedTab.classList.add('active');
-      if(popularityContainer) popularityContainer.style.display = 'none';
-      if(alphabeticalContainer) alphabeticalContainer.style.display = 'none';
-      if(sortedContainer) {
-        sortedContainer.style.display = 'grid';
-        var categoryList = document.getElementById('sorted-category-list');
-        if(categoryList) categoryList.style.display = 'grid';
-        var categoryContainers = document.querySelectorAll('.category-characters');
-        categoryContainers.forEach(function(container) {
-          container.style.display = 'none';
-        });
+      var target = containers[targetId];
+      if (target) {
+        if (targetId === 'sorted-container') {
+          target.style.display = 'block';
+          var categoryList = document.getElementById('sorted-category-list');
+          if (categoryList) categoryList.style.display = 'grid';
+          var categoryContainers = document.querySelectorAll('.category-characters');
+          categoryContainers.forEach(function(container) {
+            container.style.display = 'none';
+          });
+        } else {
+          target.style.display = 'grid';
+        }
       }
     });
-  }
+  });
 });
 
 /* -------------------------------- Mobile Nav -------------------------------- */


### PR DESCRIPTION
## Summary
- Replace three separate tab listeners with one data-driven handler in `js/main.js`
- Add `data-target` attributes to character sort tabs and drop inline script

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5388e0ecc832387b99b022345fd21