### PR TITLE
Add event-driven custom cursor states

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1331,9 +1331,24 @@ body.chapter .section-header {
   height: 64px;      /* size: adjust as needed */
   pointer-events: none;
   z-index: 9999;
-  background-image: url("data:image/x-icon;base64,AAACAAEAQEAAAAQABAAYAwAAFgAAAIlQTkcNChoKAAAADUlIRFIAAABAAAAAQAgDAAAAnbeB7AAAAGNQTFRF/tf0/tf0qY+iAAAAAAAA97C/4GuBvqG38MLJ7Lu7yYRL3q1i8NSE+eyQ9szP+r2U/+bV88nDFhIftMfH////95Wo+snTzGJFSTg4eGptYVNTyk9mKCkqHR8hsJWtoYiexKW+YVvdTAAAACF0Uk5TAP8AAP///wAAAP////8A//8A////////////////AAAAU9FoZAAAAAlwSFlzAAAPYQAAD2EBqD+naQAAAi5JREFUWIW9l4FSwjAQRBPECA2SEgoItOj/f6Ws2/NajM4oV3eGTtNkn73LJY3OXeV7zWbOPfxSzgAA6/xDf0HYAObzx6sU8Z2mBISgiKenxcIXtFyWELYAQXhfFVRG2AGICAGAqopxtXoeaLWKsYywBUg5jc0KKSHsAEwkASX7dwgLwGzGxUSA2H8KwxYAhiCGAcQ4NspdjN6v14qwAAiCkuEEiFFxKKlhEDYA7q3ey7CqQrLUKC3ipgEAMQTEmBIWFIx4abQENw3AufUay5ivWVUp1TVMCAZ2baF3OJE2AOc2GwkgxvyplGBLSZ9oEJsNERYAteOHYdstf3WNV69rfZIzRynCBkA7Jw0hNE0Iu10IdS+2moYhMJUymVYAfjqIiRGA/X4IQKtpuNljOvmhsQMsl/ycyYDDoS7ocJA/ALNsrhYAWcwsWwIweTQJLCUCuMTw+qNKvBMgiUQXi0kRamcRcZQuaBuAczjUsIvTCQQgFO5RROwlYLEY5eBugAZA+8tLvhGesHccxBQADD4eT1cxkSnh/ngE4j8AOZ/PsAPStkhh28IMxPnMMKYCoEixjaUUQs4wtL0AzDkEbm+ynGwBWNAMgEUL++nUdbB3HVsscAahRy0bgG4q3rNomMauF1PI4ro9+lsB+v//HAAhcDhTxrTmDCSSy62keD64E0DI5ULEbifXnPFRkav3l8vNYdsUoAgMlZQNW7d2e4AgvH99xfXtKm19tRsA3gE8VpIppCEbqQAAAABJRU5ErkJggg==");
   background-size: contain;
   background-repeat: no-repeat;
   will-change: transform;
   transform: none; /* no centering transform: top-left is active */
+}
+
+.custom-cursor.cursor-default {
+  background-image: url("https://kyuukei.s3.us-east-2.amazonaws.com/icon/cursor.gif");
+}
+
+.custom-cursor.cursor-select {
+  background-image: url("https://kyuukei.s3.us-east-2.amazonaws.com/icon/cursor_select.gif");
+}
+
+.custom-cursor.cursor-text {
+  background-image: url("https://kyuukei.s3.us-east-2.amazonaws.com/icon/cursor_text.gif");
+}
+
+.custom-cursor.cursor-move {
+  background-image: url("https://kyuukei.s3.us-east-2.amazonaws.com/icon/cursor_move.gif");
 }

--- a/js/main.js
+++ b/js/main.js
@@ -209,6 +209,13 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 /* ------------------------------ Custom Cursor ------------------------------ */
+function setCursorState(state) {
+  const cursor = document.getElementById('customCursor');
+  if (!cursor) return;
+  cursor.classList.remove('cursor-default', 'cursor-select', 'cursor-text', 'cursor-move');
+  cursor.classList.add(`cursor-${state}`);
+}
+
 document.addEventListener('DOMContentLoaded', function() {
   const cursor = document.getElementById('customCursor');
   let initialized = false;
@@ -233,4 +240,21 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   requestAnimationFrame(update);
+
+  setCursorState('default');
+
+  document.querySelectorAll('a, button').forEach(el => {
+    el.addEventListener('mouseenter', () => setCursorState('select'));
+    el.addEventListener('mouseleave', () => setCursorState('default'));
+  });
+
+  document.querySelectorAll('input, textarea, [contenteditable]').forEach(el => {
+    el.addEventListener('mouseenter', () => setCursorState('text'));
+    el.addEventListener('mouseleave', () => setCursorState('default'));
+  });
+
+  document.addEventListener('lb-panning-start', () => setCursorState('move'));
+  document.addEventListener('lb-panning-end', () => setCursorState('default'));
+  document.addEventListener('panningstart', () => setCursorState('move'));
+  document.addEventListener('panningend', () => setCursorState('default'));
 });


### PR DESCRIPTION
## Summary
- style cursor images for default, select, text, and move states
- toggle cursor images via `setCursorState` and interaction listeners

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c548582bd88323ba2ec94ba1b1c103