### PR TITLE
Preload cursor images and fade in custom cursor

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,11 @@
   <link rel="stylesheet" href="{{ '/css/style.css' | relative_url }}">
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
 
+  <link rel="preload" as="image" href="https://kyuukei.s3.us-east-2.amazonaws.com/icon/cursor.gif">
+  <link rel="preload" as="image" href="https://kyuukei.s3.us-east-2.amazonaws.com/icon/cursor_select.gif">
+  <link rel="preload" as="image" href="https://kyuukei.s3.us-east-2.amazonaws.com/icon/cursor_text.gif">
+  <link rel="preload" as="image" href="https://kyuukei.s3.us-east-2.amazonaws.com/icon/cursor_move.gif">
+
   <!-- Favicon & Apple Touch Icon -->
   <link rel="icon" href="https://kyuukei.s3.us-east-2.amazonaws.com/icon/comfavicon.gif" type="image/png">
   <link rel="shortcut icon" href="https://kyuukei.s3.us-east-2.amazonaws.com/icon/comfavicon.gif" type="image/png">
@@ -46,6 +51,8 @@
     will-change: transform;
     /* No transform, so the top-left corner is the active point */
     transform: none;
+    opacity: 0;
+    transition: opacity 0.2s;
   }
 </style>
 

--- a/css/style.css
+++ b/css/style.css
@@ -1323,7 +1323,7 @@ body.chapter .section-header {
 
 /* Custom cursor default styling (normal state) */
 .custom-cursor {
-  display: none; /* hidden until first mouse move */
+  opacity: 0; /* hidden until first mouse move */
   position: fixed;
   top: 0;
   left: 0;
@@ -1335,6 +1335,7 @@ body.chapter .section-header {
   background-repeat: no-repeat;
   will-change: transform;
   transform: none; /* no centering transform: top-left is active */
+  transition: opacity 0.2s;
 }
 
 .custom-cursor.cursor-default {

--- a/js/main.js
+++ b/js/main.js
@@ -227,7 +227,7 @@ document.addEventListener('DOMContentLoaded', function() {
     y = e.clientY;
 
     if (!initialized && cursor) {
-      cursor.style.display = 'block';
+      cursor.style.opacity = '1';
       initialized = true;
     }
   });


### PR DESCRIPTION
## Summary
- Preload custom cursor GIFs in page head for faster rendering
- Hide custom cursor with opacity and fade in on first pointer move
- Keep cursor hidden by CSS to prevent system cursor during transitions

## Testing
- `jekyll build` *(command not found)*
- `bundle exec jekyll build` *(Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c54a98fc788323aa7e2eaf178d1d88