### PR TITLE
Enable custom cursor on character profile image

### DIFF
--- a/_layouts/character.html
+++ b/_layouts/character.html
@@ -19,7 +19,7 @@ layout: default
     <!-- Right Panel: Character Image and Basic Info -->
     <div class="right-panel">
       <div class="image-container">
-        <img src="{{ page.image }}" alt="{{ page.title }}" id="character-pfp" style="cursor: zoom-in;">
+        <img src="{{ page.image }}" alt="{{ page.title }}" id="character-pfp" style="cursor: zoom-in;" data-cursor="select">
       </div>
       <div class="basic-info">
         {% if page.age %}<p><strong>Age:</strong> {{ page.age }}</p>{% endif %}

--- a/js/main.js
+++ b/js/main.js
@@ -238,7 +238,7 @@ function init() {
 
   setCursorState('default');
 
-  document.querySelectorAll('a, button').forEach(el => {
+  document.querySelectorAll('a, button, [data-cursor="select"]').forEach(el => {
     el.addEventListener('mouseenter', () => setCursorState('select'));
     el.addEventListener('mouseleave', () => setCursorState('default'));
   });


### PR DESCRIPTION
## Summary
- mark character profile image with `data-cursor="select"`
- extend custom cursor script to activate `cursor-select` on `[data-cursor="select"]`

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c550e4aa0883238a18e0f3c2c4ce72