### PR TITLE
Use nav link for character detail back button

### DIFF
--- a/_layouts/character.html
+++ b/_layouts/character.html
@@ -5,9 +5,9 @@ layout: default
 <div class="character-detail">
   <!-- Back Button Container for Centering -->
   <div class="back-btn-container" style="text-align: center; margin-bottom: 1rem;">
-    <button class="back-select-btn" onclick="window.history.back();">
+    <a class="back-select-btn nav-link" href="{{ '/characters/' | relative_url }}">
       Back to Character Selection
-    </button>
+    </a>
   </div>
 
   <div class="detail-container">

--- a/css/style.css
+++ b/css/style.css
@@ -206,7 +206,9 @@ header {
   align-items: center;
 }
 .nav-menu-desktop li { margin: 0 15px; }
-.nav-menu-desktop a {
+.nav-menu-desktop a,
+.nav-link {
+  display: inline-block;
   font-weight: 500;
   background: #f7cdd5; /* Orby Pink background */
   color: #fff;        /* White text */
@@ -216,16 +218,19 @@ header {
   border-radius: 5px;
   transition: background 0.3s ease, color 0.3s ease;
 }
-.nav-menu-desktop a:hover { background: #e0a8b5; }
+.nav-menu-desktop a:hover,
+.nav-link:hover { background: #e0a8b5; }
 
 /* Active Desktop Menu Link */
-.nav-menu-desktop a.active {
+.nav-menu-desktop a.active,
+.nav-link.active {
   background: #e0a8b5; /* Darker Orby Pink */
 }
 
 /* Responsive adjustments for desktop menu when viewport is below 750px */
 @media (max-width: 750px) {
-  .nav-menu-desktop a {
+  .nav-menu-desktop a,
+  .nav-link {
     font-size: 1.3rem;
     padding: 6px 10px;
   }
@@ -642,21 +647,9 @@ header {
   border-right: 1px solid #eee;
 }
 
-/* Back to Character Selection Button styled in Blue */
+/* Back to Character Selection link */
 .character-detail .back-select-btn {
-  display: inline-block;
   margin-bottom: 20px;
-  padding: 8px 12px;
-  font-size: 0.9em;
-  background: #f7cdd5 !important;
-  color: #fff !important;
-  border: none !important;
-  border-radius: 4px !important;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2) !important;
-}
-
-.character-detail .back-select-btn:hover {
-  background: #e0a8b5 !important;
 }
 
 .section-title {
@@ -833,20 +826,7 @@ body.chapter .section-header {
   color: #333;
 }
 
-.character-detail .back-select-btn {
-  background-color: #f7cdd5 !important;
-  color: #fff !important;
-  border: none !important;
-  border-radius: 4px !important;
-  padding: 8px 12px !important;
-  font-size: 0.9rem !important;
-  cursor: pointer !important;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2) !important;
-}
-
-.character-detail .back-select-btn:hover {
-  background-color: #e0a8b5 !important;
-}
+/* (Deprecated styling removed; nav-link handles appearance) */
 
 @media (max-width: 800px) {
   .section-header h1 {
@@ -1313,13 +1293,6 @@ body.chapter .section-header {
 .lb { cursor: default !important; }      /* at base zoom (not pannable) */
 .lb.pannable { cursor: grab !important; }  /* zoomed-in but not dragging */
 .lb.panning  { cursor: grabbing !important; } /* actively dragging */
-
-/* Ensure .back-select-btn and its children always hide the native cursor */
-.back-select-btn,
-.back-select-btn:hover,
-.back-select-btn * {
-  cursor: none !important;
-}
 
 /* Custom cursor default styling (normal state) */
 .custom-cursor {

--- a/js/main.js
+++ b/js/main.js
@@ -237,7 +237,7 @@ function init() {
   requestAnimationFrame(update);
 
   setCursorState('default');
-
+  // Apply select-state cursor to navigational links and buttons
   document.querySelectorAll('a, button, [data-cursor="select"]').forEach(el => {
     el.addEventListener('mouseenter', () => setCursorState('select'));
     el.addEventListener('mouseleave', () => setCursorState('default'));


### PR DESCRIPTION
## Summary
- Replace character detail back button with an anchor using site navigation styles
- Share header nav styling via new `.nav-link` class and drop redundant cursor overrides
- Clarify custom cursor logic for navigational links and buttons

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c551cb69308323ac5cc3eb2bf3f6e9