### PR TITLE
Restore back button appearance with shared nav styling

### DIFF
--- a/_layouts/character.html
+++ b/_layouts/character.html
@@ -5,7 +5,7 @@ layout: default
 <div class="character-detail">
   <!-- Back Button Container for Centering -->
   <div class="back-btn-container" style="text-align: center; margin-bottom: 1rem;">
-    <button class="back-select-btn" onclick="window.history.back();">
+    <button class="back-select-btn nav-link" onclick="window.history.back();">
       Back to Character Selection
     </button>
   </div>

--- a/css/style.css
+++ b/css/style.css
@@ -206,22 +206,26 @@ header {
   align-items: center;
 }
 .nav-menu-desktop li { margin: 0 15px; }
-.nav-menu-desktop a {
+.nav-menu-desktop a,
+.nav-link {
   font-weight: 500;
   background: #f7cdd5; /* Orby Pink background */
   color: #fff;        /* White text */
   text-decoration: none;
-  font-size: 1.5rem;
-  padding: 8px 15px;
   border-radius: 5px;
   transition: background 0.3s ease, color 0.3s ease;
 }
-.nav-menu-desktop a:hover { background: #e0a8b5; }
+.nav-menu-desktop a {
+  font-size: 1.5rem;
+  padding: 8px 15px;
+  display: inline-block;
+}
+.nav-menu-desktop a:hover,
+.nav-link:hover { background: #e0a8b5; }
 
 /* Active Desktop Menu Link */
-.nav-menu-desktop a.active {
-  background: #e0a8b5; /* Darker Orby Pink */
-}
+.nav-menu-desktop a.active,
+.nav-link.active { background: #e0a8b5; }
 
 /* Responsive adjustments for desktop menu when viewport is below 750px */
 @media (max-width: 750px) {
@@ -1314,12 +1318,6 @@ body.chapter .section-header {
 .lb.pannable { cursor: grab !important; }  /* zoomed-in but not dragging */
 .lb.panning  { cursor: grabbing !important; } /* actively dragging */
 
-/* Ensure .back-select-btn and its children always hide the native cursor */
-.back-select-btn,
-.back-select-btn:hover,
-.back-select-btn * {
-  cursor: none !important;
-}
 
 /* Custom cursor default styling (normal state) */
 .custom-cursor {


### PR DESCRIPTION
## Summary
- Revert oversized nav link change to keep character page back control a button
- Introduce reusable `.nav-link` styles and apply to back button without affecting size
- Drop redundant cursor-hiding rules so button relies on global navigation cursor handling

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c551cb69308323ac5cc3eb2bf3f6e9