### PR TITLE
Add composer credit to character music sections

### DIFF
--- a/_characters/Elaine.md
+++ b/_characters/Elaine.md
@@ -21,6 +21,7 @@ music:
   enabled: true
   title: "The theme of Elaine Sternbruch @cresdot"
   src: "/assets/music/elaine-sternbruch-theme.wav"
+  credit: "@cresdot"
 ---
 
 ## Background

--- a/_layouts/character.html
+++ b/_layouts/character.html
@@ -37,6 +37,9 @@ layout: default
       {% if page.music and page.music.enabled %}
       <div class="character-music" data-audio-src="{{ page.music.src | relative_url }}">
         <p class="music-title">{{ page.music.title }}</p>
+        {% if page.music.credit %}
+        <p class="music-credit"><strong>Music by:</strong> {{ page.music.credit }}</p>
+        {% endif %}
         <div class="music-controls">
           <button type="button" class="music-toggle" aria-label="Play audio" data-state="paused">▶</button>
           <div class="music-progress" role="slider" aria-label="Seek through track" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" tabindex="0">

--- a/css/style.css
+++ b/css/style.css
@@ -717,6 +717,11 @@ header {
   font-weight: 600;
   color: #333;
 }
+.music-credit {
+  margin: 0 0 10px;
+  font-size: 0.95em;
+  color: #444;
+}
 .music-controls {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- render optional composer credit alongside character music players
- style music credit text for character pages
- record composer handle for Elaine's theme

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69218002d05883238bdfbf24edcbd9b8)